### PR TITLE
Added try/catch on file cleanup.

### DIFF
--- a/19_Profiling/python_example/simulation.py
+++ b/19_Profiling/python_example/simulation.py
@@ -45,7 +45,15 @@ def timestep(pos):
 
 def cleanup(traj_file):
     for filepath in glob.glob(traj_file + "*"):
-        os.remove(filepath)
+        try:
+            os.remove(filepath)
+        except (FileNotFoundError):
+            # Trying to remove the 'traj.dat' file but it's already been removed.
+            # This can happen sometimes due to a race condition if multiple instances
+            # of the script are running. In production code, we would avoid this
+            # by using formal temp files/directories, but for this example we don't
+            # care as long as the file's gone, so just ignore the error.
+            pass
 
 
 def simulate(pos, traj_file, write_fun):


### PR DESCRIPTION
As per Alex's emailed feedback on 1/25/22, there's sometimes an error when running multiple instances of `simulation.py` due to potentially trying to delete an already-deleted `traj.dat` file.

Since it is just an example, I haven't worried about how this would impact results-correctness, I just threw in a try-catch to avoid the error and a comment explaining the potential race condition. Feel free to reject this if you feel a more robust solution is warranted (I'm never sure just how rigorous we need to be about modeling best practices for these examples).

@blackwer mentioning you here since I don't want to modify your code without your ok